### PR TITLE
Add support for more complex server topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,24 @@ all the configuration required for the master there.
 
 The log by default are placed in /srv/logs/. The directory must be created manually
 before use on the main server, and cannot be configured for now.
+
+# Handling complex domain topology
+
+By default, the role will only accept peer matching *.`ansible_domain` as their hostname.
+While this is fine for a simple project, a more complex setup might requires more granularity,
+and so you can use  2 variables for that, `authorized_domains` and `authorized_peers`.
+
+For example, if you have your server named rsyslog.yul.example.org and some servers named
+client.sin.example.org, client2.sin.example.org and client3.bne.example.org, you could handle this
+with this playbooks:
+
+```
+- hosts: all
+  roles:
+  - role: rsyslog
+    syslog_server: rsyslog.yul.example.org
+    authorized_peers:
+    - client3.bne.example.org
+    authorized_domains:
+    - sin.example.org
+```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,2 @@
+authorized_domains: []
+authorized_peers: []

--- a/templates/listen_tls.conf
+++ b/templates/listen_tls.conf
@@ -13,6 +13,14 @@ $DefaultNetstreamDriverKeyFile  {{ key_file }}
 
 $InputTCPServerStreamDriverAuthMode x509/name
 $InputTCPServerStreamDriverPermittedPeer *.{{ ansible_domain }}
+{% for d in authorized_domains %}
+$InputTCPServerStreamDriverPermittedPeer *.{{ d }}
+{% endfor %}
+{% for p in authorized_peers %}
+$InputTCPServerStreamDriverPermittedPeer {{ p }}
+{% endfor %}
+
+
 $InputTCPServerStreamDriverMode 1 # run driver in TLS-only mode
 $InputTCPServerRun 514 
 


### PR DESCRIPTION
I found out with gluster infra (using subdomain per DC) that
the syslog was refusing lots of clients, and thus causing ressources
and slow down some services (like ssh on supercolony or mailman)
