### PR TITLE
Use the current list of hosts as authorized peers

### DIFF
--- a/templates/listen_tls.conf
+++ b/templates/listen_tls.conf
@@ -12,7 +12,9 @@ $DefaultNetstreamDriverCertFile {{ cert_file }}
 $DefaultNetstreamDriverKeyFile  {{ key_file }}
 
 $InputTCPServerStreamDriverAuthMode x509/name
-$InputTCPServerStreamDriverPermittedPeer *.{{ ansible_domain }}
+{% for peer in ansible_play_hosts %}
+$InputTCPServerStreamDriverPermittedPeer {{ peer }}
+{% endfor %}
 $InputTCPServerStreamDriverMode 1 # run driver in TLS-only mode
 $InputTCPServerRun 514 
 


### PR DESCRIPTION
Using the domain is not working when we have a more complex
topology as seen with gluster infra. So we should
rather whitelist all the services were we are currently
deploying rsyslog.
