### PR TITLE
No longer filter by name, only by certificate

### DIFF
--- a/templates/listen_tls.conf
+++ b/templates/listen_tls.conf
@@ -11,8 +11,7 @@ $DefaultNetstreamDriverCAFile   {{ ca_file }}
 $DefaultNetstreamDriverCertFile {{ cert_file }}
 $DefaultNetstreamDriverKeyFile  {{ key_file }}
 
-$InputTCPServerStreamDriverAuthMode x509/name
-$InputTCPServerStreamDriverPermittedPeer *.{{ ansible_domain }}
+$InputTCPServerStreamDriverAuthMode x509/certvalid
 $InputTCPServerStreamDriverMode 1 # run driver in TLS-only mode
 $InputTCPServerRun 514 
 


### PR DESCRIPTION
Since freeipa is used for the certificates issuance, we can rely
on it for being used only on our servers. Removing the filtering
based on peer name permit to handle non flat domain name
like the one of gluster.org
